### PR TITLE
Added HTTP server capability to expose EC2 IAM role metadata-like out…

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ eval $(aws-sts-helper get-token --mfa-arn $MFA_ARN \
                                 and-show-export)
 ```
 
+### Credential server ###
+It may be useful to serve the temporary credentials retrieved from STS over HTTP as if the credentials came from an 
+[EC2 instance metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) endpoint. Some 
+applications such as [Cyberduck](https://trac.cyberduck.io/wiki/help/en/howto/s3) do not support temporary credentials 
+by default but can fetch them from an HTTP endpoint exposing them as an EC2 instance would.
+
+To start a web server serving the the credentials as JSON on port 3000 under `/credentials`:
+```shell
+aws-sts-helper get-token --mfa-arn $MFA_ARN \
+                         --role-arn $ROLE_ARN \
+                         and-serve-via-http
+```
 
 ## Help ##
 It is built into the program:

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,9 @@ type ConfigEntries struct {
 	MfaArn       string
 	MfaTokenCode string
 
+	HttpPort int
+	HttpPath string
+
 	Debug              bool
 	KeepAwsEnvironment bool
 }

--- a/helper.go
+++ b/helper.go
@@ -1,13 +1,12 @@
 package main
 
 import (
-	"./config"
-	"./sts"
-
 	"math/rand"
 	"os"
 	"time"
 
+	"./config"
+	"./sts"
 	log "github.com/Sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -60,6 +59,25 @@ func appDefinition() (app *cli.App) {
 					Name:   "and-show-export",
 					Usage:  "Get new temporary STS credentials and print out the environment variable 'export' commands to use them.",
 					Action: sts.GetTokenAndReturnExportEnvironment,
+				},
+				{
+					Name:   "and-serve-via-http",
+					Usage:  "Get new temporary STS credentials and start an HTTP server serving the retrieved credentials for use by application compatible with EC2 IAM role retrieval (e.g. Cyberduck).",
+					Action: sts.GetTokenAndServeOverHttp,
+					Flags: []cli.Flag{
+						cli.IntFlag{
+							Name:        "port",
+							Value:       3000,
+							Usage:       "The port on which the HTTP server should expose the temporary credentials.",
+							Destination: &config.Config.HttpPort,
+						},
+						cli.StringFlag{
+							Name:        "path",
+							Value:       "/credentials",
+							Usage:       "The URL path at which the HTTP server should expose the temporary credentials.",
+							Destination: &config.Config.HttpPath,
+						},
+					},
 				},
 			},
 			Flags: []cli.Flag{

--- a/sts/model.go
+++ b/sts/model.go
@@ -1,0 +1,11 @@
+package sts
+
+type IamRoleResponse struct {
+	Code            string `json:"code"`
+	LastUpdate      string `json:"LastUpdated"`
+	Type            string `json:"Type"`
+	AccessKeyId     string `json:"AccessKeyId"`
+	SecretAccessKey string `json:"SecretAccessKey"`
+	Token           string `json:"Token"`
+	Expiration      string `json:"Expiration"`
+}


### PR DESCRIPTION
…put for applications that do not support temporary credentials out-of-the-box but can leverage IAM profile attached to EC2 instances