### PR TITLE
Updated logrus import path to fix #3 for good

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,12 @@ build: vet test
 	@mkdir -p $(BUILD_DIR)
 	GOOS=linux GOARCH=amd64 $(GO_BUILD_CMD) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64
 	GOOS=darwin GOARCH=amd64 $(GO_BUILD_CMD) -o $(BUILD_DIR)/$(BINARY_NAME)-osx-amd64
+	GOOS=windows GOARCH=amd64 $(GO_BUILD_CMD) -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64
 
 package:
 	tar -C $(BUILD_DIR) -zcf $(BUILD_DIR)/$(BINARY_NAME)-$(APP_VERSION)-linux-amd64.tar.gz $(BINARY_NAME)-linux-amd64
 	tar -C $(BUILD_DIR) -zcf $(BUILD_DIR)/$(BINARY_NAME)-$(APP_VERSION)-osx-amd64.tar.gz $(BINARY_NAME)-osx-amd64
+	zip -q -j  $(BUILD_DIR)/$(BINARY_NAME)-$(APP_VERSION)-windows-amd64.zip $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64
 
 clean:
 	rm -Rf $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,12 @@ build: vet test
 	@mkdir -p $(BUILD_DIR)
 	GOOS=linux GOARCH=amd64 $(GO_BUILD_CMD) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64
 	GOOS=darwin GOARCH=amd64 $(GO_BUILD_CMD) -o $(BUILD_DIR)/$(BINARY_NAME)-osx-amd64
-	GOOS=windows GOARCH=amd64 $(GO_BUILD_CMD) -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64
+	GOOS=windows GOARCH=amd64 $(GO_BUILD_CMD) -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe
 
 package:
 	tar -C $(BUILD_DIR) -zcf $(BUILD_DIR)/$(BINARY_NAME)-$(APP_VERSION)-linux-amd64.tar.gz $(BINARY_NAME)-linux-amd64
 	tar -C $(BUILD_DIR) -zcf $(BUILD_DIR)/$(BINARY_NAME)-$(APP_VERSION)-osx-amd64.tar.gz $(BINARY_NAME)-osx-amd64
-	zip -q -j  $(BUILD_DIR)/$(BINARY_NAME)-$(APP_VERSION)-windows-amd64.zip $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64
+	zip -q -j  $(BUILD_DIR)/$(BINARY_NAME)-$(APP_VERSION)-windows-amd64.zip $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe
 
 clean:
 	rm -Rf $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 Never set environment variables yourself anymore when using _AssumeRole_ and temporary credentials from [STS](https://www.google.se/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=0ahUKEwiz1tTdicjOAhWBGywKHQyzCGMQFggdMAA&url=http%3A%2F%2Fdocs.aws.amazon.com%2FSTS%2Flatest%2FAPIReference%2FWelcome.html&usg=AFQjCNHIkvYM6R9tkhrAsp4O9fHqjr0nTw) (Amazon Security Token Service).
 
 ## Download ##
-Precompiled binaries are available for Linux and macOS. Check the [latest release](https://github.com/nicolas-nannoni/aws-sts-helper/releases/latest).
+Precompiled binaries are available for Linux, macOS and Windows (note: I do not test it on Windows, shell operations support must be limited, but it has been [reported to work](https://github.com/nicolas-nannoni/aws-sts-helper/issues/5#issuecomment-343071645)). 
+Check the [latest release](https://github.com/nicolas-nannoni/aws-sts-helper/releases/latest).
 
 ## Quick start ##
 Set the following environment variables to the values you use the most:

--- a/helper.go
+++ b/helper.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/nicolas-nannoni/aws-sts-helper/config"
 	"github.com/nicolas-nannoni/aws-sts-helper/sts"
 	"github.com/urfave/cli"

--- a/sts/sts.go
+++ b/sts/sts.go
@@ -15,7 +15,7 @@ import (
 
 	json2 "encoding/json"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/nicolas-nannoni/aws-sts-helper/config"
 	"github.com/urfave/cli"


### PR DESCRIPTION
Restored Windows build capabilities
Added Windows binaries packaging logic

Windows binaries of that version: [aws-sts-helper-1.2.0-PR8-windows-amd64.zip](https://github.com/nicolas-nannoni/aws-sts-helper/files/1458755/aws-sts-helper-1.2.0-PR8-windows-amd64.zip)
