### PR TITLE
print executable name on output instead of static value

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,13 +5,15 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"math/rand"
+	"os"
+	"path/filepath"
 	"time"
 )
 
 func NewRootCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use:     "aws-sts-helper <command>",
+		Use:     filepath.Base(os.Args[0]) + " <command>",
 		Short:   "Tool to make your life easier when using Amazon STS (Security Token Service).",
 		Version: config.AppVersion + " (build " + config.AppBuild + ")",
 

--- a/sts/sts.go
+++ b/sts/sts.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -60,7 +61,7 @@ func GetTokenAndReturnExportEnvironment(roleArn, mfaArn, tokenCode string) {
 		credentials = resp.Credentials
 	}
 
-	logrus.Info("Run this command wrapped in 'eval $(aws-sts-helper get-token ...)' to automatically set your AWS environment variables.")
+	logrus.Info("Run this command wrapped in 'eval $(" + filepath.Base(os.Args[0]) + " get-token ...)' to automatically set your AWS environment variables.")
 	fmt.Println(getSetEnvironmentStringFromCredentials(credentials))
 }
 
@@ -88,7 +89,7 @@ func ClearAwsEnvironmentInNewShell() {
 
 func ClearAwsEnvironmentAndReturnUnsetEnvironment() {
 
-	logrus.Info("Run this command wrapped in 'eval $(aws-sts-helper clear-environment ...)' to automatically set your AWS environment variables.")
+	logrus.Info("Run this command wrapped in 'eval $(" + filepath.Base(os.Args[0]) + " clear-environment ...)' to automatically set your AWS environment variables.")
 	fmt.Println(getUnsetEnvironmentString())
 
 }
@@ -236,7 +237,7 @@ func getRandomSessionName() string {
 	for i := 0; i < randomSessionNameLength; i++ {
 		result[i] = chars[rand.Intn(len(chars))]
 	}
-	return fmt.Sprintf("aws-sts-helper-%s", string(result))
+	return fmt.Sprintf("%s-%s", filepath.Base(os.Args[0]), string(result))
 }
 
 func openNewShell() {


### PR DESCRIPTION
Hello,

I have a simple PR proposal just for consistency. Indeed, executable file name can be different from aws-sts-helper.

This little change modify the hard coded aws-sts-helper value to filepath.Base(os.Args[0]) so the output will always be consistent with the filename.